### PR TITLE
feat: Exclude empty words from sitemap and add noindex

### DIFF
--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -4,8 +4,8 @@ class SitemapController < ActionController::Base
     # Set appropriate headers for XML sitemap
     response.headers['Content-Type'] = 'application/xml; charset=utf-8'
     
-    # Get all words ordered by updated_at for efficient caching
-    @words = Word.all.order(:updated_at)
+    # Get only words with content ordered by updated_at for efficient caching
+    @words = Word.has_content.order(:updated_at)
     
     # Cache the sitemap for 1 hour
     expires_in 1.hour, public: true

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -46,6 +46,21 @@ class Word < ApplicationRecord
       .distinct
   }
 
+  # Scope for words with content
+  scope :has_content, -> {
+    joins(:rich_text_body)
+      .where.not(action_text_rich_texts: { body: [nil, ''] })
+      .distinct
+  }
+
+  # Scope for words without content
+  scope :empty_content, -> {
+    left_outer_joins(:rich_text_body)
+      .where(action_text_rich_texts: { body: [nil, ''] })
+      .or(left_outer_joins(:rich_text_body).where(action_text_rich_texts: { id: nil }))
+      .distinct
+  }
+
   def self.find(input)
     if input.is_a?(Integer)
       super

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,6 +8,7 @@ html lang="en"
     meta name="turbolinks-cache-control" content="#{yield('turolinks-cache')}" /
     title= content_for?(:title) ? "#{yield(:title)} | #{site_title}" : site_title
     = csrf_meta_tags
+    = yield(:meta_tags)
     = stylesheet_link_tag "application", :media => "all"
     = javascript_importmap_tags
     = include_gon

--- a/app/views/sitemap/index.xml.builder
+++ b/app/views/sitemap/index.xml.builder
@@ -35,12 +35,12 @@ xml.urlset xmlns: 'http://www.sitemaps.org/schemas/sitemap/0.9' do
     end
   end
   
-  # Tag pages (if any tags exist)
-  if Word.tag_counts_on(:tags).any?
-    Word.tag_counts_on(:tags).find_each do |tag|
+  # Tag pages (if any tags exist for words with content)
+  if Word.has_content.tag_counts_on(:tags).any?
+    Word.has_content.tag_counts_on(:tags).find_each do |tag|
       xml.url do
         xml.loc word_tag_url(tag_list: tag.name)
-        xml.lastmod @words.tagged_with(tag.name).maximum(:updated_at)&.iso8601
+        xml.lastmod Word.has_content.tagged_with(tag.name).maximum(:updated_at)&.iso8601
         xml.changefreq 'weekly'
         xml.priority '0.5'
       end

--- a/app/views/words/show.html.slim
+++ b/app/views/words/show.html.slim
@@ -1,5 +1,9 @@
 - content_for(:title) { "#{@word.title}" } 
 
+- if @word.body.blank?
+  - content_for(:meta_tags) do
+    meta name="robots" content="noindex, nofollow"
+
 .py-2
   .row
     .col-12


### PR DESCRIPTION
## Summary
- コンテンツが空のWordをsitemapから除外
- コンテンツが空のWordにnoindex, nofollowメタタグを追加
- 検索エンジンのインデックス品質を向上

## Changes
- Wordモデルに`has_content`と`empty_content`スコープを追加
- Sitemapコントローラーをコンテンツがあるwordのみ含むよう修正
- application.html.slimに柔軟なメタタグ挿入のための`yield(:meta_tags)`を追加
- words/show.html.slimにコンテンツが空の場合のnoindexメタタグを追加
- sitemapのタグページもコンテンツがあるwordに関連するタグのみ表示するよう更新

## Test plan
- [ ] コンテンツが空のWordページにアクセスし、HTMLソースで`<meta name="robots" content="noindex, nofollow">`が含まれることを確認
- [ ] コンテンツがあるWordページにアクセスし、noindexメタタグが含まれないことを確認
- [ ] `/sitemap.xml`にアクセスし、コンテンツが空のWordが含まれていないことを確認
- [ ] タグページのURLもコンテンツがあるWordに関連するタグのみ含まれることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)